### PR TITLE
leiningen 1.3.1 moves dev-dependencies to lib/dev

### DIFF
--- a/swank-clojure.el
+++ b/swank-clojure.el
@@ -332,13 +332,18 @@ The `path' variable is bound to the project root when these functions run.")
         (swank-clojure-extra-vm-args (copy-list swank-clojure-extra-vm-args))
         (swank-clojure-binary nil)
         (swank-clojure-classpath (let ((l (expand-file-name
-                                           swank-clojure-project-dep-path path)))
+                                           swank-clojure-project-dep-path path))
+				       (d (expand-file-name "lib/dev" path)))
                                    (if (file-directory-p l)
                                        (append
-                                        (directory-files l t ".jar$")
-                                        (remove-if-not
-                                         'directoryp
-                                         (directory-files l t "^[^\\.]")))))))
+					(append
+					 (directory-files l t ".jar$")
+					 (remove-if-not 'directoryp
+ 					  (directory-files l t "^[^\\.]")))
+					(append
+					 (directory-files d t ".jar$")
+					 (remove-if-not 'directoryp
+ 					  (directory-files d t "^[^\\.]"))))))))
 
     (add-to-list 'swank-clojure-classpath (expand-file-name "classes/" path))
     (add-to-list 'swank-clojure-classpath (expand-file-name "src/" path))


### PR DESCRIPTION
swank-clojure-project needs to take that into account.

The dev-dependencies directory in leiningen does not seem to be configurable and dependencies in jar form will always be placed in lib/dev.

When swank-clojure-classpath is build, lib/dev was not searched for jars. 

This patch that takes this into account.

Faithfully,
Karsten Lang
