### PR TITLE
Patch to use repl-init-script in 'lein swank'

### DIFF
--- a/src/leiningen/swank.clj
+++ b/src/leiningen/swank.clj
@@ -8,7 +8,7 @@
   ([project port host & opts]
      (eval-in-project project
                       `(do
-                         (let [is# ~(:init-script project)
+                         (let [is# ~(:repl-init-script project)
                                gis# ~(get-global-init-script)]
                            (when (not (nil? gis#))
                              (load-file gis#))

--- a/src/leiningen/swank.clj
+++ b/src/leiningen/swank.clj
@@ -5,7 +5,11 @@
   "Launch swank server for Emacs to connect. Optionally takes PORT and HOST."
   ([project port host & opts]
      (eval-in-project project
-                      `(do (require '~'swank.swank)
+                      `(do
+                         (let [is# ~(:init-script project)]
+                           (when is#
+                             (load-file is#)))
+                         (require '~'swank.swank)
                            (@(ns-resolve '~'swank.swank '~'start-repl)
                             (Integer. ~port)
                             ~@(concat (map read-string opts)

--- a/src/leiningen/swank.clj
+++ b/src/leiningen/swank.clj
@@ -8,10 +8,7 @@
   ([project port host & opts]
      (eval-in-project project
                       `(do
-                         (let [is# ~(:repl-init-script project)
-                               gis# ~(get-global-init-script)]
-                           (when (not (nil? gis#))
-                             (load-file gis#))
+                         (let [is# ~(:repl-init-script project)]
                            (when (and (not (nil? is#)) (.exists (File. (str is#))))
                              (load-file is#)))
                          (require '~'swank.swank)

--- a/src/leiningen/swank.clj
+++ b/src/leiningen/swank.clj
@@ -1,6 +1,5 @@
 (ns leiningen.swank
-  (:use [leiningen.compile :only [eval-in-project]]
-        [leiningen.core :only [get-global-init-script]])
+  (:use [leiningen.compile :only [eval-in-project]])
   (:import [java.io File]))
 
 (defn swank

--- a/src/leiningen/swank.clj
+++ b/src/leiningen/swank.clj
@@ -1,5 +1,6 @@
 (ns leiningen.swank
-  (:use [leiningen.compile :only [eval-in-project]]))
+  (:use [leiningen.compile :only [eval-in-project]])
+  (:import [java.io File]))
 
 (defn swank
   "Launch swank server for Emacs to connect. Optionally takes PORT and HOST."
@@ -7,7 +8,7 @@
      (eval-in-project project
                       `(do
                          (let [is# ~(:init-script project)]
-                           (when is#
+                           (when (and is# (.exists (File. is#)))
                              (load-file is#)))
                          (require '~'swank.swank)
                            (@(ns-resolve '~'swank.swank '~'start-repl)

--- a/src/leiningen/swank.clj
+++ b/src/leiningen/swank.clj
@@ -1,5 +1,6 @@
 (ns leiningen.swank
-  (:use [leiningen.compile :only [eval-in-project]])
+  (:use [leiningen.compile :only [eval-in-project]]
+        [leiningen.core :only [get-global-init-script]])
   (:import [java.io File]))
 
 (defn swank
@@ -7,13 +8,16 @@
   ([project port host & opts]
      (eval-in-project project
                       `(do
-                         (let [is# ~(:init-script project)]
-                           (when (and is# (.exists (File. is#)))
+                         (let [is# ~(:init-script project)
+                               gis# ~(get-global-init-script)]
+                           (when (not (nil? gis#))
+                             (load-file gis#))
+                           (when (and (not (nil? is#)) (.exists (File. (str is#))))
                              (load-file is#)))
                          (require '~'swank.swank)
-                           (@(ns-resolve '~'swank.swank '~'start-repl)
-                            (Integer. ~port)
-                            ~@(concat (map read-string opts)
-                                      [:host host])))))
+                         (@(ns-resolve '~'swank.swank '~'start-repl)
+                          (Integer. ~port)
+                          ~@(concat (map read-string opts)
+                                    [:host host])))))
   ([project port] (swank project port "localhost"))
   ([project] (swank project 4005)))


### PR DESCRIPTION
This patch allows to execute commands, specified in repl-init-script in swank's context
