### PR TITLE
Improvements to swank-clojure

### DIFF
--- a/src/swank/commands/basic.clj
+++ b/src/swank/commands/basic.clj
@@ -465,7 +465,9 @@ that symbols accessible in the current namespace go first."
 (defslimefn buffer-first-change [file-name] nil)
 
 (defn locals-for-emacs [m]
-  (map #(list :name (name (first %)) :id 0 :value (str (second %))) m))
+  (sort-by second
+           (map #(list :name (name (first %)) :id 0
+                       :value (str (second %))) m)))
 
 (defslimefn frame-catch-tags-for-emacs [n] nil)
 (defslimefn frame-locals-for-emacs [n]

--- a/src/swank/commands/contrib/swank_arglists.clj
+++ b/src/swank/commands/contrib/swank_arglists.clj
@@ -3,6 +3,43 @@
 
 ((slime-fn 'swank-require) :swank-c-p-c)
 
+(defn position-in-params? [params pos]
+  (or (some #(= '& %) params)
+      (<= pos (count params))))
+
+;; (position-in-params? '[x y] 2)
+
+(defn highlight-position [params pos]
+  (if (<= pos (count (take-while #(not= % '&) params)))
+    (into [] (concat (take (dec pos) params)
+                     '(===>)
+                     (list (nth params (dec pos)))
+                     '(<===)
+                     (drop pos params)))
+    (if (some #(= % '&) params)
+      (into [] (concat (take-while #(not= % '&) params)
+                       '(===>)
+                       '(&)
+                       (list (last params))
+                       '(<===))))))
+
+;; (highlight-position '[x y] 1)
+
+(defn highlight-param-lists [params-list pos]
+  (loop [checked []
+         current (first params-list)
+         remaining (rest params-list)]
+    (if (position-in-params? current pos)
+      (concat checked
+              [(highlight-position current pos)]
+              remaining)
+      (when (seq remaining)
+        (recur (conj checked current)
+               (first remaining)
+               (rest remaining))))))
+
+;; (highlight-param-lists '([fname & body]) 1)
+
 (defslimefn arglist-for-echo-area [raw-specs & options]
   (let [{:keys [arg-indices
                 print-right-margin
@@ -11,7 +48,13 @@
     (if (and raw-specs
              (seq? raw-specs)
              (seq? (first raw-specs)))
-      ((slime-fn 'operator-arglist) (ffirst raw-specs) *current-package*)
+      (let [result ((slime-fn 'operator-arglist) (ffirst raw-specs) *current-package*)
+            pos (first (second options))
+            cmd (ffirst raw-specs)]
+        (str cmd ": "
+             (if (or (zero? pos) (nil? result))
+               nil
+               (apply list (highlight-param-lists (read-string result) pos)))))
       nil)))
 
 (defslimefn variable-desc-for-echo-area [variable-name]


### PR DESCRIPTION
I'd love to see these improvements be pulled so others will use them and can improve on them.
- function name in autodoc (like eldoc/CL-slime) (let me know if you know how to color it like font-lock-function-name)
- highlight current arg (very basic version, in a few situations it will highlight wrong arg)
- sort locals by name in break point

Also do you know of an easy way to display strings with quotes in slime inspector? I think that's a really important improvement otherwise you can't tell the difference between "slime" and 'slime or 1 and "1" just by looking at them.
