### PR TITLE
More verbose errors on read-loop failure

### DIFF
--- a/src/swank/core/protocol.clj
+++ b/src/swank/core/protocol.clj
@@ -40,7 +40,11 @@
   ([#^java.io.Reader reader]
      (let [len  (Integer/parseInt (read-chars reader 6 read-fail-exception) 16)
            msg  (read-chars reader len read-fail-exception)
-           form (read-string (fix-namespace msg))]
+           form (try
+                  (read-string (fix-namespace msg))
+                  (catch Exception ex
+                    (.println System/err (format "unreadable message: %s" msg))
+                    (throw ex)))]
        (if (seq? form)
          (deep-replace {'t true} form)
          form))))

--- a/src/swank/swank.clj
+++ b/src/swank/swank.clj
@@ -12,6 +12,7 @@
   (:use [swank.core]
         [swank.core connection server]
         [swank.util.concurrent thread]
+        [swank.util.net sockets]
         [clojure.main :only [repl]])
   (:require [swank.commands]
             [swank.commands basic indent completion
@@ -31,7 +32,8 @@
            (control-loop conn)
            (catch Exception e
              ;; fail silently
-             nil)))
+             nil))
+          (close-socket! (conn :socket)))
         read
         (dothread-swank
           (thread-set-name "Read Loop Thread")

--- a/src/swank/swank.clj
+++ b/src/swank/swank.clj
@@ -39,6 +39,8 @@
            (read-loop conn control)
            (catch Exception e
              ;; This could be put somewhere better
+             (.println System/err "exception in read loop")
+             (.printStackTrace e)
              (.interrupt control)
              (dosync (alter connections (partial remove #{conn}))))))]
     (dosync


### PR DESCRIPTION
Problem: swank client writes something unreadable.  swank-clojure server's read-loop thread dies, as does the control thread, but the user's only indication is that the server stops responding.  No error message is printed, no stack dump is printed (not that I could find at least), and the connection remains open.

These changes will print a stack dump to stderr and shut down the connection on a reader error.

This was inspired by trying to use my recent CVS SLIME including slime-autodoc-mode against swank-clojure and getting nothing but unresponsive SLIME repl since (read-string) can't read `swank::%cursor-marker%`.
