### PR TITLE
Bug fix for recently copied print-doc

### DIFF
--- a/src/swank/commands/basic.clj
+++ b/src/swank/commands/basic.clj
@@ -181,11 +181,11 @@
 
 (defn- describe-symbol* [symbol-name]
   (with-emacs-package
-    (if-let [v (try
-                 (ns-resolve (maybe-ns *current-package*) (symbol symbol-name))
+    (let [v (try (ns-resolve (maybe-ns *current-package*) (symbol symbol-name))
                  (catch ClassNotFoundException e nil))]
-      (describe-to-string v)
-      (str "Unknown symbol " symbol-name))))
+      (if (var? v)
+        (describe-to-string v)
+        (str "Unknown symbol " symbol-name)))))
 
 (defslimefn describe-symbol [symbol-name]
   (describe-symbol* symbol-name))

--- a/src/swank/commands/basic.clj
+++ b/src/swank/commands/basic.clj
@@ -209,7 +209,7 @@
 
 (defn- describe-to-string [var]
   (with-out-str
-    (print-doc var)))
+    (print-doc (meta var))))
 
 (defn- describe-symbol* [symbol-name]
   (with-emacs-package


### PR DESCRIPTION
The version of print-doc introduced in 527a6d9fa36ecd089f22a755749d7efdf07772da takes a var's metadata map as its argument, not the var itself.
