### PR TITLE
- fix maybe-resolve-sym for clojure 1.3 (beta1)

### DIFF
--- a/src/swank/commands/basic.clj
+++ b/src/swank/commands/basic.clj
@@ -185,7 +185,14 @@
 (defn- maybe-resolve-sym [symbol-name]
   (try
     (ns-resolve (maybe-ns *current-package*) (symbol symbol-name))
-    (catch ClassNotFoundException e nil)))
+    (catch ClassNotFoundException e nil)
+    ;; in clojure 1.3 a RuntimeException is being thrown
+    (catch RuntimeException e
+      (if (= (type (.getCause e))
+             ClassNotFoundException)
+        nil
+        ;; re-throw anything that is not a ClassNotFoundException
+        (throw e)))))
 
 (defn- maybe-resolve-ns [sym-name]
   (let [sym (symbol sym-name)]


### PR DESCRIPTION
I'm using clojure 1.3 and whenever I use auto-complete I get ClassNotFoundException errors when I type in: "clojure." (or anything with a trailing dot which causes the auto completion window to pop up). I remember the error back with clojure 1.2 - and apparently with clojure 1.3 the exception which is being thrown on ns-resolve has changed. This is a fix for that.
