### PR TITLE
Add functionality to cleanly shutdown the swank server

### DIFF
--- a/src/swank/commands/basic.clj
+++ b/src/swank/commands/basic.clj
@@ -30,7 +30,8 @@
          :version ~(deref protocol-version)))
 
 (defslimefn quit-lisp []
-  (System/exit 0))
+  (and @exit-on-quit?
+       (System/exit 0)))
 
 (defslimefn toggle-debug-on-swank-error []
   (alter-var-root #'swank.core/debug-swank-clojure not))

--- a/src/swank/core.clj
+++ b/src/swank/core.clj
@@ -21,6 +21,8 @@
 
 (def color-support? (atom false))
 
+(def exit-on-quit? (atom true))
+
 (def sldb-stepping-p nil)
 (def sldb-initial-frames 10)
 (def #^{:dynamic true} #^{:doc "The current level of recursive debugging."}

--- a/src/swank/core/cdt_utils.clj
+++ b/src/swank/core/cdt_utils.clj
@@ -90,8 +90,8 @@
 (defn get-system-thread-groups [] @system-thread-groups)
 
 (def system-thread-names
-     #{#"^CDT Event Handler$" #"^Swank Control Thread$" #"^Read Loop Thread$"
-       #"^Socket Server \[\d*\]$"})
+     #{#"^CDT Event Handler$" #"^Swank Control Thread$" #"^Swank Read Loop Thread$"
+       #"^Swank Socket Server \[\d*\]$"})
 
 (defn system-thread? [t]
   (some #(re-find % (.name t)) system-thread-names))

--- a/src/swank/swank.clj
+++ b/src/swank/swank.clj
@@ -62,6 +62,7 @@
       (reset! shutting-down? false)
       (let [opts (apply hash-map opts)]
         (reset! color-support? (:colors? opts false))
+        (reset! exit-on-quit? (:exit-on-quit opts true))
         (when (:load-cdt-on-startup opts)
           (load-cdt-with-dynamic-classloader))
         (reset! current-server

--- a/src/swank/swank.clj
+++ b/src/swank/swank.clj
@@ -82,7 +82,7 @@
       (reset! shutting-down? true)
       (doseq [c @connections]
         (doseq [t [:control-thread :read-thread :repl-thread]]
-          (when-let [thread @(c t)]
+          (when-let [^Thread thread @(c t)]
             (.interrupt thread))))
       (close-server-socket! @current-server)
       (dosync (ref-set connections []))

--- a/src/swank/swank.clj
+++ b/src/swank/swank.clj
@@ -1,5 +1,5 @@
 (ns swank.swank
-  (:use [swank.core]
+  (:use [swank core util]
         [swank.core connection server]
         [swank.util.concurrent thread]
         [swank.util.net sockets]
@@ -12,6 +12,8 @@
            [java.io File])
   (:gen-class))
 
+(def current-server (atom nil))
+
 (defn ignore-protocol-version [version]
   (reset! protocol-version version))
 
@@ -22,21 +24,23 @@
           (try
            (control-loop conn)
            (catch Exception e
-             (.println System/err "exception in control loop")
-             (.printStackTrace e)
+             (when-not @shutting-down?
+               (.println System/err "exception in control loop")
+               (.printStackTrace e))
              nil))
           (close-socket! (conn :socket)))
         read
         (dothread-swank
-          (thread-set-name "Read Loop Thread")
+          (thread-set-name "Swank Read Loop Thread")
           (try
            (read-loop conn control)
            (catch Exception e
              ;; This could be put somewhere better
-             (.println System/err "exception in read loop")
-             (.printStackTrace e)
-             (.interrupt control)
-             (dosync (alter connections (partial remove #{conn}))))))]
+             (when-not @shutting-down?
+               (.println System/err "exception in read loop")
+               (.printStackTrace e)
+               (.interrupt control)
+               (dosync (alter connections (partial remove #{conn})))))))]
     (dosync
      (ref-set (conn :control-thread) control)
      (ref-set (conn :read-thread) read))))
@@ -52,17 +56,37 @@
   "Start the server and write the listen port number to
    PORT-FILE. This is the entry point for Emacs."
   [& opts]
-  (let [opts (apply hash-map opts)]
-    (reset! color-support? (:colors? opts false))
-    (when (:load-cdt-on-startup opts)
-      (load-cdt-with-dynamic-classloader))
-    (setup-server (get opts :port 0)
-                  simple-announce
-                  connection-serve
-                  opts)
-    (when (:block opts)
-      (doseq [#^Thread t (get-thread-list)]
-         (.join t)))))
+  (if @current-server
+    (println System/err "Swank server already running")
+    (do
+      (reset! shutting-down? false)
+      (let [opts (apply hash-map opts)]
+        (reset! color-support? (:colors? opts false))
+        (when (:load-cdt-on-startup opts)
+          (load-cdt-with-dynamic-classloader))
+        (reset! current-server
+                (setup-server (get opts :port 0)
+                              simple-announce
+                              connection-serve
+                              opts))
+        (when (:block opts)
+          (doseq [#^Thread t (get-thread-list)]
+            (.join t)))))))
+
+(defn stop-server
+  "Stop the currently running server, shutdown its threads, and release the port."
+  []
+  (if @current-server
+    (do
+      (reset! shutting-down? true)
+      (doseq [c @connections]
+        (doseq [t [:control-thread :read-thread :repl-thread]]
+          (when-let [thread @(c t)]
+            (.interrupt thread))))
+      (close-server-socket! @current-server)
+      (dosync (ref-set connections []))
+      (reset! current-server nil))
+    (println System/err "Swank server not running")))
 
 (defn start-repl
   "Start the server wrapped in a repl. Use this to embed swank in your code."

--- a/src/swank/util.clj
+++ b/src/swank/util.clj
@@ -2,6 +2,8 @@
   (:import (java.io StringReader)
            (clojure.lang LineNumberingPushbackReader)))
 
+(def shutting-down? (atom false))
+
 (defmacro one-of?
   "Short circuiting value comparison."
   ([val & possible]
@@ -64,7 +66,7 @@
            (apply ~f args#))))))
 
 (defmacro continuously [& body]
-  `(loop [] ~@body (recur)))
+  `(loop [] ~@body (when-not @shutting-down? (recur))))
 
 (defmacro failing-gracefully [& body]
   `(try

--- a/src/swank/util/net/sockets.clj
+++ b/src/swank/util/net/sockets.clj
@@ -36,10 +36,14 @@
    server to close."
   ([server-socket handle-socket]
      (dothread-keeping-clj nil
-       (thread-set-name (str "Socket Server [" (thread-id) "]"))
+       (thread-set-name (str "Swank Socket Server [" (thread-id) "]"))
        (with-open [#^ServerSocket server server-socket]
          (while (not (.isClosed server))
-           (handle-socket (.accept server)))))))
+           (try
+             (handle-socket (.accept server))
+             (catch SocketException e
+               (when-not @shutting-down?
+                 (throw e)))))))))
 
 (defn close-socket!
   "Cleanly shutdown and close a java.net.Socket. This will not affect

--- a/src/swank/util/sys.clj
+++ b/src/swank/util/sys.clj
@@ -14,7 +14,7 @@
 (defn #^java.lang.Process cmd [p]
   (.. Runtime getRuntime (exec (str p))))
 
-(defn cmdout [o]
+(defn cmdout [^Process o]
   (let [r (BufferedReader.
            (InputStreamReader. (.getInputStream o)))]
     (line-seq r)))


### PR DESCRIPTION
This adds (stop-server), which shuts down the threads and sockets created by (start-server), allowing the server to be stopped without exiting the JVM.

Also included is an option to prevent a quit from slime from exiting the JVM, and prefixing some of the thread names with 'Swank' so their purpose is clearer in a thread list.
