### PR TITLE
Restore java.io imports in sys.clj

### DIFF
--- a/src/swank/util/sys.clj
+++ b/src/swank/util/sys.clj
@@ -1,4 +1,5 @@
-(ns swank.util.sys)
+(ns swank.util.sys
+  (:import (java.io BufferedReader InputStreamReader)))
 
 (defn get-pid
   "Returns the PID of the JVM. This is largely a hack and may or may


### PR DESCRIPTION
This breaks swank-clojure 1.4.1. It looks like these got lost when you cherry-picked my patches back from master.
