### PR TITLE
Bold note in the usage section regarding other slime versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ If you are still using Leiningen 1.x, you will need to do
 
 That's all it takes; there are no extra install steps beyond
 `clojure-mode` on the Emacs side and the `swank-clojure` plugin on the
-Leiningen side. In particular be sure you don't have any other
-versions of Slime installed; see "Troubleshooting" below.
+Leiningen side. In particular, be sure you **don't have any other
+versions of SLIME loaded**; see "Troubleshooting" below.
 
 ## SLIME Commands
 


### PR DESCRIPTION
For the benefit of late-night lispers trying to set up a clojure environment, I feel it should be clearer that your existing SLIME set up will -break-. I think bolding it is enough for now.
