### PR TITLE
Handle ClassNotFoundExceptions wrapped in RuntimeExceptions when resolving namespaces 

### DIFF
--- a/src/swank/commands/basic.clj
+++ b/src/swank/commands/basic.clj
@@ -210,7 +210,9 @@
   (try
     (ns-resolve (maybe-ns *current-package*) (symbol symbol-name))
     (catch ClassNotFoundException e nil)
-    (catch RuntimeException e nil)))
+    (catch RuntimeException e (if (instance? ClassNotFoundException (.getCause e))
+                                nil
+                                (throw e)))))
 
 (defn- maybe-resolve-ns
   "Returns a Namespace or nil"


### PR DESCRIPTION
Stops exceptions being thrown in Emacs's autocomplete mode when autocompleting namespaces.
