### PR TITLE
Try .toString on current-exception before defaulting to "No message."

### DIFF
--- a/src/swank/core.clj
+++ b/src/swank/core.clj
@@ -142,7 +142,9 @@ values."
          (map #(exception-str width %) (.getStackTrace #^Throwable t)))))
 
 (defmethod debugger-condition-for-emacs :default []
-  (list (or (.getMessage #^Throwable *current-exception*) "No message.")
+  (list (or (.getMessage #^Throwable *current-exception*)
+            (.toString #^Throwable *current-exception*)
+            "No message.")
         (str "  [Thrown " (class *current-exception*) "]")
         nil))
 


### PR DESCRIPTION
Some Exceptions have a null message but toString provides valuable information. [Cassandra's InvalidRequestException](https://github.com/apache/cassandra/blob/trunk/interface/thrift/gen-java/org/apache/cassandra/thrift/InvalidRequestException.java) is an example.

This change tries .getMessage, then .toString before defaulting to "No message."
